### PR TITLE
Patch to be compatible with indicatif==0.17.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ askama = "0.10"
 color-eyre = "0.5"
 console = "0.14.0"
 happylog = { version = "0.2.0", features = ["structopt"] }
-indicatif = "0.16.0"
+indicatif = "0.17.0"
 itertools = "0.9.0"
 log = "0.4.11"
 mime_guess = "2.0.3"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,11 +3,12 @@ use itertools::Itertools;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Display;
+use std::time::Duration;
 
 pub(crate) fn with_progress<T, F: FnMut() -> T>(msg: &'static str, mut f: F) -> T {
     let bar = ProgressBar::new_spinner();
     bar.set_message(msg);
-    bar.enable_steady_tick(16);
+    bar.enable_steady_tick(Duration::new(16, 0));
 
     let _state = happylog::set_progress(&bar);
 


### PR DESCRIPTION
Hello!

I was looking at rendering OneNote files and noticed there was an issue with building from source. Might be similar to https://github.com/msiemens/one2html/issues/13?

I was able to use my fork for [Assemblyline's Document Preview service](https://github.com/CybercentreCanada/assemblyline-service-document-preview/pull/32) and figured the fix might be applicable to the issue as well.

Can't wait for support for files created from the desktop apps! 😀